### PR TITLE
docs: Actualizacion de commit-msg

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,14 +1,32 @@
 #!/bin/sh
-
 echo "🔍 Validando mensaje de commit..."
+
+# Expresión regular del formato: tipo: descripción mínima de 10 caracteres
 commit_regex="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert): .{10,}$"
 commit_msg=$(cat "$1")
 
 if ! echo "$commit_msg" | grep -Eq "$commit_regex"; then
+  echo ""
   echo "❌ Mensaje de commit inválido."
-  echo "📌 Usa el formato: 'tipo: Descripción mínima de 10 caracteres'"
-  echo "Ejemplo: 'feat: Agregar login con Google'"
+  echo "--------------------------------------------------"
+  echo "📌 Formato esperado: 'tipo: descripción de al menos 10 caracteres'"
+  echo "🔧 Tipos válidos:"
+  echo "   feat     → Nueva funcionalidad"
+  echo "   fix      → Corrección de errores"
+  echo "   docs     → Cambios en documentación"
+  echo "   style    → Formato, estilo, sin afectar código"
+  echo "   refactor → Refactorización de código"
+  echo "   perf     → Mejora de rendimiento"
+  echo "   test     → Agregar o corregir pruebas"
+  echo "   chore    → Tareas generales o mantenimiento"
+  echo "   ci       → Cambios en configuración CI/CD"
+  echo "   build    → Cambios que afectan el build"
+  echo "   revert   → Revertir un commit"
+  echo ""
+  echo "📝 Ejemplo válido:"
+  echo "   feat: Agregar login con Google"
+  echo "--------------------------------------------------"
   exit 1
 fi
 
-echo "✅ Mensaje válido."
+echo "✅ Mensaje válido. ¡Buen trabajo! 🚀"


### PR DESCRIPTION
# Cambios
- Se hizo el cambio del commit-msg para que sea mas descriptivo al momento de decirte si un commit esta mal y cuales son las recomendaciones que puedes ocupar