### PR TITLE
feat: Correcion del color de texto cards experiencia

### DIFF
--- a/src/components/features/aboutMe/Items/ItemDataExperiencia.tsx
+++ b/src/components/features/aboutMe/Items/ItemDataExperiencia.tsx
@@ -38,16 +38,16 @@ export const ItemDataExperiencia: React.FC<ModalWorkProps> = ({
                   </span>
                 )}
               </h3>
-              <span className="flex justify-center items-center gap-2 text-sm text-gray-300">
+              <span className="flex justify-center items-center gap-2 text-sm text-base-content/90">
                 <span>{v.iconoEmpresa && <v.iconoEmpresa />}</span>
                 {subtitle}
               </span>
 
-              <span className="flex justify-center items-center gap-2 text-sm text-gray-500">
+              <span className="flex justify-center items-center gap-2 text-sm text-base-content/60">
                 <span>{v.iconoReloj && <v.iconoReloj />}</span>
                 {time}
               </span>
-              <span className="flex justify-center items-center gap-2 text-sm text-gray-500">
+              <span className="flex justify-center items-center gap-2 text-sm text-base-content/60">
                 <span>{v.iconoUbicacion && <v.iconoUbicacion />}</span>
                 {location}
               </span>


### PR DESCRIPTION
# Cambios
- Correcion de color en el titulo de la empresa ya que en modo claro no se veia correctamente y se veia de un color claro en modo claro haciendo que el texto no se vea correctamente
![image](https://github.com/user-attachments/assets/0ea868dc-514c-46d8-a663-e6a8350116b2)
![image](https://github.com/user-attachments/assets/106502a6-70b3-404f-a1b7-9987b9d9b41b)

